### PR TITLE
perf(decoder): use primitive integers

### DIFF
--- a/iabtcf-decoder/pom.xml
+++ b/iabtcf-decoder/pom.xml
@@ -99,9 +99,9 @@
             <artifactId>junit</artifactId>
         </dependency>
 
-	<dependency>
-	  <groupId>org.hamcrest</groupId>
-	  <artifactId>hamcrest-library</artifactId>
-	</dependency>
+        <dependency>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-library</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/iabtcf-decoder/src/test/java/com/iabtcf/decoder/BitReaderTest.java
+++ b/iabtcf-decoder/src/test/java/com/iabtcf/decoder/BitReaderTest.java
@@ -37,7 +37,6 @@ import java.util.stream.Stream;
 
 import org.junit.Test;
 
-import com.iabtcf.decoder.TCString;
 import com.iabtcf.exceptions.ByteParseException;
 import com.iabtcf.utils.BitReader;
 import com.iabtcf.utils.FieldDefs;

--- a/iabtcf-decoder/src/test/java/com/iabtcf/utils/LengthOffsetCacheTest.java
+++ b/iabtcf-decoder/src/test/java/com/iabtcf/utils/LengthOffsetCacheTest.java
@@ -1,0 +1,59 @@
+package com.iabtcf.utils;
+
+/*-
+ * #%L
+ * IAB TCF Core Library
+ * %%
+ * Copyright (C) 2020 IAB Technology Laboratory, Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.iabtcf.utils.LengthOffsetCache.LeanEnumArrayIntMap;
+
+public class LengthOffsetCacheTest {
+
+    private final FieldDefs[] fd = FieldDefs.values();
+
+    @Test
+    public void testLeanEnumArrayIntMap() {
+        final LeanEnumArrayIntMap<FieldDefs> map = new LeanEnumArrayIntMap<>(FieldDefs.CORE_VERSION);
+        for (int i = 0; i < fd.length; i++) {
+            assertFalse(map.contains(fd[i]));
+        }
+
+        for (int i = 0; i < fd.length; i++) {
+            map.put(fd[i], 99999);
+            for (int j = 0; j < fd.length; j++) {
+                if (j == i) {
+                    assertTrue(map.contains(fd[j]));
+                    assertEquals(99999, map.get(fd[j]));
+                } else {
+                    assertFalse(map.contains(fd[j]));
+                }
+            }
+
+            map.remove(fd[i]);
+            for (int j = 0; j < fd.length; j++) {
+                assertFalse(map.contains(fd[j]));
+            }
+        }
+    }
+}

--- a/iabtcf-encoder/src/test/java/com/iabtcf/encoder/TCStringV2EncoderTest.java
+++ b/iabtcf-encoder/src/test/java/com/iabtcf/encoder/TCStringV2EncoderTest.java
@@ -125,7 +125,9 @@ public class TCStringV2EncoderTest {
 
         assertEquals(1, tcf.split("\\.").length);
         assertEquals(2, decoded.getVersion());
-        assertEquals(created.truncatedTo(ChronoUnit.DAYS), decoded.getCreated());
+        /* We are using the value of updated field in the builder to populate the created in order to
+           keep the values of created and update same as per the new TCF specifications. */
+        assertEquals(updated.truncatedTo(ChronoUnit.DAYS), decoded.getCreated());
         assertEquals(updated.truncatedTo(ChronoUnit.DAYS), decoded.getLastUpdated());
         assertEquals(1, decoded.getCmpId());
         assertEquals(12, decoded.getCmpVersion());

--- a/pom.xml
+++ b/pom.xml
@@ -292,13 +292,12 @@
                 <scope>test</scope>
             </dependency>
 
-	    <dependency>
-	      <groupId>org.hamcrest</groupId>
-	      <artifactId>hamcrest-library</artifactId>
-	      <version>1.3</version>
-	      <scope>test</scope>
-	    </dependency>
-
+            <dependency>
+              <groupId>org.hamcrest</groupId>
+              <artifactId>hamcrest-library</artifactId>
+              <version>1.3</version>
+              <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
To ensure we don't use unnecessarily boxed integers, we use `ToIntFunction` in all of the `FieldDefs` components. We also create a `LeanEnumArrayIntMap` to effectively do the same in the `LengthOffsetCache`. Also added some bounds checks to `vendorIdsFromRange()`. We've seen this give a further 1.25x speed improvement in eager `TCString.decode()`.

Semi-unrelated, but I also found a test case in `TCStringV2EncoderTest` that fails when run between 23:00 and 00:00 UTC. I fixed it in accordance with the comment in `TCStringEncoder.TCStringEncoderV2` whereby the last update time is used in lieu of the creation time.