### PR TITLE
perf(decoder): leaner bit set with less invariant checking

### DIFF
--- a/iabtcf-decoder/src/main/java/com/iabtcf/utils/BitReader.java
+++ b/iabtcf-decoder/src/main/java/com/iabtcf/utils/BitReader.java
@@ -391,7 +391,7 @@ public class BitReader {
      * @throws ByteParseException
      */
     public BitSet readBitSet(int offset, int length, int resultShift) {
-        final BitSet bs = new BitSet(length);
+        final UnsafeLeanBitSet bs = new UnsafeLeanBitSet(resultShift + length);
         int i = 0;
         while (i < length) {
             final int remaining = length - i;
@@ -414,13 +414,13 @@ public class BitReader {
                 i += remaining;
             }
         }
-        return bs;
+        return bs.toBitSet();
     }
 
-    private void fillBitSetWithContent(BitSet bs, long content, int size, int offset) {
+    private void fillBitSetWithContent(UnsafeLeanBitSet bs, long content, int size, int offset) {
         for (int j = 0; j < size; j++) {
             if (((content >>> (size - 1 - j)) & 1) == 1) {
-                bs.set(offset + j);
+                bs.unsafeSet(offset + j, true);
             }
         }
     }

--- a/iabtcf-decoder/src/main/java/com/iabtcf/utils/LengthOffsetCache.java
+++ b/iabtcf-decoder/src/main/java/com/iabtcf/utils/LengthOffsetCache.java
@@ -58,17 +58,17 @@ class LengthOffsetCache {
      * @param <K> Enum type
      */
     static class LeanEnumArrayIntMap<K extends Enum<K>> {
-        private final long[] existence;
+        private final UnsafeLeanBitSet existence;
         private final int[] values;
 
         LeanEnumArrayIntMap(final K example) {
             final K[] constants = example.getDeclaringClass().getEnumConstants();
-            this.existence = new long[(constants.length >>> 6) + ((constants.length & 0x3f) == 0 ? 0 : 1)];
+            this.existence = new UnsafeLeanBitSet(constants.length);
             this.values = new int[constants.length];
         }
 
         boolean contains(final K key) {
-            return getBit(key.ordinal());
+            return existence.unsafeGet(key.ordinal());
         }
 
         int get(final K key) {
@@ -77,25 +77,11 @@ class LengthOffsetCache {
 
         void put(final K key, final int value) {
             values[key.ordinal()] = value;
-            setBit(key.ordinal(), true);
+            existence.unsafeSet(key.ordinal(), true);
         }
 
         void remove(final K key) {
-            setBit(key.ordinal(), false);
-        }
-
-        private boolean getBit(final int index) {
-            final int wordIndex = index >>> 6;
-            final int bitIndex = index & 0x3f;
-            return ((existence[wordIndex] >>> bitIndex) & 1) == 1;
-        }
-
-        private void setBit(final int index, final boolean flag) {
-            final int wordIndex = index >>> 6;
-            final int bitIndex = index & 0x3f;
-            existence[wordIndex] = flag
-                    ? existence[wordIndex] | (1L << bitIndex)
-                    : existence[wordIndex] & (~(1L << bitIndex));
+            existence.unsafeSet(key.ordinal(), false);
         }
     }
 }

--- a/iabtcf-decoder/src/main/java/com/iabtcf/utils/UnsafeLeanBitSet.java
+++ b/iabtcf-decoder/src/main/java/com/iabtcf/utils/UnsafeLeanBitSet.java
@@ -1,0 +1,119 @@
+package com.iabtcf.utils;
+
+/*-
+ * #%L
+ * IAB TCF Java Decoder Library
+ * %%
+ * Copyright (C) 2020 - 2023 IAB Technology Laboratory, Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Arrays;
+import java.util.BitSet;
+
+/**
+ * This class provides some basic BitSet functionality similar to the one in standard library.
+ * If fact, much of the code here is analogous or identical to the standard library code.
+ *
+ * However, this class does not perform nearly as much invariant checking on every operation.
+ * It is up to the user to ensure the underlying storage has enough capacity by either
+ * initializing with a fixed length and never indexing beyond that, or by calling the
+ * provided method(s) to ensure capacity for the maximum expected number of bits to work with.
+ *
+ * As a result, this performs decently faster for the required operations at high scale
+ * when compared to the standard library's BitSet. Needless to say, this is intended only for
+ * judicious use within this module. Proceed with extreme caution.
+ */
+public class UnsafeLeanBitSet {
+
+    private static final long WORD_MASK = 0xffffffffffffffffL;
+
+    private long[] words;
+
+    public UnsafeLeanBitSet(final int nbits) {
+        if (nbits < 0) {
+            throw new NegativeArraySizeException("nbits < 0: " + nbits);
+        }
+        words = new long[wordIndex(nbits) + (bitIndex(nbits) == 0 ? 0 : 1)];
+    }
+
+    public BitSet toBitSet() {
+        return BitSet.valueOf(words);
+    }
+
+    private static int wordIndex(final int bit) {
+        return bit >> 6;
+    }
+
+    private static int bitIndex(final int bit) {
+        return bit & 0x3f;
+    }
+
+    public void ensureCapacity(final int nbits) {
+        final int wordsRequired = 1 + wordIndex(nbits - 1);
+        if (words.length < wordsRequired) {
+            words = Arrays.copyOf(words, Math.max(2 * words.length, wordsRequired));
+        }
+    }
+
+    public boolean unsafeGet(final int bit) {
+        final int wordIndex = wordIndex(bit);
+        final int bitIndex = bitIndex(bit);
+        return ((words[wordIndex] >>> bitIndex) & 1) == 1;
+    }
+
+    public void unsafeSet(final int bit, final boolean flag) {
+        final int wordIndex = wordIndex(bit);
+        final int bitIndex = bitIndex(bit);
+        words[wordIndex] = flag
+                ? words[wordIndex] | (1L << bitIndex)
+                : words[wordIndex] & (~(1L << bitIndex));
+    }
+
+    public void unsafeSet(final int startBit, final int endBit, final boolean flag) {
+        if (endBit <= startBit) {
+            return;
+        }
+
+        final int startWordIndex = wordIndex(startBit);
+        final int endWordIndex = wordIndex(endBit - 1);
+        final long firstWordMask = WORD_MASK << startBit;
+        final long lastWordMask  = WORD_MASK >>> -endBit;
+
+        // Mostly taken verbatim from BitSet standard library code.
+        if (flag) {
+            if (startWordIndex == endWordIndex) {
+                words[startWordIndex] |= (firstWordMask & lastWordMask);
+            } else {
+                words[startWordIndex] |= firstWordMask;
+                for (int i = startWordIndex + 1; i < endWordIndex; i++) {
+                    words[i] = WORD_MASK;
+                }
+                words[endWordIndex] |= lastWordMask;
+            }
+
+        } else {
+            if (startWordIndex == endWordIndex) {
+                words[startWordIndex] &= ~(firstWordMask & lastWordMask);
+            } else {
+                words[startWordIndex] &= ~firstWordMask;
+                for (int i = startWordIndex + 1; i < endWordIndex; i++) {
+                    words[i] = 0;
+                }
+                words[endWordIndex] &= ~lastWordMask;
+            }
+        }
+    }
+}

--- a/iabtcf-decoder/src/test/java/com/iabtcf/utils/UnsafeLeanBitSetTest.java
+++ b/iabtcf-decoder/src/test/java/com/iabtcf/utils/UnsafeLeanBitSetTest.java
@@ -1,0 +1,115 @@
+package com.iabtcf.utils;
+
+/*-
+ * #%L
+ * IAB TCF Java Decoder Library
+ * %%
+ * Copyright (C) 2020 - 2023 IAB Technology Laboratory, Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class UnsafeLeanBitSetTest {
+
+    @Test
+    public void testUnsafeLeanBitSetSingleOperations() {
+        UnsafeLeanBitSet bs = new UnsafeLeanBitSet(0);
+        assertTrue(bs.toBitSet().isEmpty());
+
+        // BitSet will optimize to strip trailing unset bits.
+        bs.ensureCapacity(1000);
+        assertEquals(0, bs.toBitSet().toLongArray().length);
+        bs.unsafeSet(999, true);
+        assertEquals(16, bs.toBitSet().toLongArray().length);
+
+        // Test single set
+        bs = new UnsafeLeanBitSet(0);
+        bs.ensureCapacity(1);
+        bs.unsafeSet(0, true);
+        assertTrue(bs.unsafeGet(0));
+        assertEquals(1, bs.toBitSet().toLongArray().length);
+
+        bs.ensureCapacity(64);
+        bs.unsafeSet(63, true);
+        assertTrue(bs.unsafeGet(63));
+        assertFalse(bs.unsafeGet(62));
+        bs.unsafeSet(63, true);
+        assertTrue(bs.unsafeGet(63));
+        assertFalse(bs.unsafeGet(62));
+        assertEquals(1, bs.toBitSet().toLongArray().length);
+
+        bs.ensureCapacity(65);
+        bs.unsafeSet(64, true);
+        assertTrue(bs.unsafeGet(64));
+        assertTrue(bs.unsafeGet(63));
+        assertFalse(bs.unsafeGet(62));
+        assertEquals(2, bs.toBitSet().toLongArray().length);
+
+        // Test single clear
+        bs.unsafeSet(0, false);
+        assertFalse(bs.unsafeGet(0));
+        assertFalse(bs.unsafeGet(1));
+
+        bs.unsafeSet(50, false);
+        assertFalse(bs.unsafeGet(49));
+        assertFalse(bs.unsafeGet(50));
+        assertFalse(bs.unsafeGet(51));
+
+        bs.unsafeSet(63, false);
+        assertFalse(bs.unsafeGet(62));
+        assertFalse(bs.unsafeGet(63));
+        assertTrue(bs.unsafeGet(64));
+
+        bs.unsafeSet(64, false);
+        for (int i = 0; i < 65; i++) {
+            assertFalse(bs.unsafeGet(i));
+        }
+    }
+
+    @Test
+    public void testUnsafeLeanBitSetBulkOperations() {
+        UnsafeLeanBitSet bs = new UnsafeLeanBitSet(0);
+        assertTrue(bs.toBitSet().isEmpty());
+
+        // BitSet will optimize to strip trailing unset bits.
+        bs.ensureCapacity(1000);
+        bs.unsafeSet(2, 100, true);
+        assertEquals(2, bs.toBitSet().toLongArray().length);
+        for (int i = 0; i < 1000; i++) {
+            if (i >= 2 && i < 100) {
+                assertTrue(bs.unsafeGet(i));
+            } else {
+                assertFalse(bs.unsafeGet(i));
+            }
+        }
+
+        bs.unsafeSet(60, 70, false);
+        bs.unsafeSet(63, 65, true);
+        bs.unsafeSet(40, false);
+        bs.unsafeSet(61, true);
+        for (int i = 0; i < 1000; i++) {
+            if (i >= 2 && i < 100 && i != 40 && i != 60 && i != 62 && !(i >= 65 && i < 70)) {
+                assertTrue(bs.unsafeGet(i));
+            } else {
+                assertFalse(bs.unsafeGet(i));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduce `UnsafeLeanBitSet`, a stripped down flavor of standard library's
`BitSet` that doesn't do as much invariant checking. It requires the caller,
primarily just the code in this module, to always be aware of how much space
they've allocated for its storage, and to never request any operation on an
out-of-bounds index. If unsure, simply calling `ensureCapacity()` with a number
1 higher than any index a caller is about to operate on will always be safe.

This change tweaks `TCStringV1`, `TCStringV2`, and `LeanEnumArrayIntMap` to
leverage this new data structure. Testing this on our production workload seems
to give an extra 10 to 15 percent performance boost.